### PR TITLE
fix: add lacking function unpipe() to request obj

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -67,6 +67,10 @@ export class Request extends Readable {
     this.socket.destroy(err)
   }
 
+  unpipe(writable) {
+    writable.destroy()
+  }
+
   _read(cb) {
     if (this.destroyed || this.destroying || this.socket.destroyed) return cb()
 


### PR DESCRIPTION
Fix lacking function. Absence caused Unhandled Promise Rejection with @fastify/multipart